### PR TITLE
ble_decoder: Always trust the direction field from the sniffer or pcap

### DIFF
--- a/src/ble_decoder.c
+++ b/src/ble_decoder.c
@@ -1066,8 +1066,8 @@ static ble_packet_decode_res_t packet_decode(ble_info_t *info, uint8_t recursion
 											__LINE__);
 									}
 #endif
+								}
 							}
-						}
 							else
 							{
 								// unknown
@@ -1119,6 +1119,11 @@ static ble_packet_decode_res_t packet_decode(ble_info_t *info, uint8_t recursion
 			{
 				// if the sniffer or pcap file does not provide the packet direction, use calculated one
 				info->dir = conn.current_packet_direction;
+			}
+			else
+			{
+				// if the sniffer or pcap file does provide the packet direction, always use it
+				conn.current_packet_direction = info->dir;
 			}
 
 			if (info->channel == -1)


### PR DESCRIPTION
Calculated packet direction resulted in the wrong direction.
Most likely because of the sniffer version 4 packet format, which has changed the time field from a delta value to a timestamp value.
Using the direction field from the sniffer trace it is possible to decrypt the connection when the nrf sniffer is sending the encrypted payload + MIC when this has MIC failure.